### PR TITLE
limit the number of selected topics and keywords

### DIFF
--- a/inst/qml/qml_components/CochraneInput.qml
+++ b/inst/qml/qml_components/CochraneInput.qml
@@ -44,8 +44,9 @@ Section
 
 		AssignedVariablesList
 		{
-			name:	"topicsSelected"
-			title:	qsTr("Selected")
+			name:		"topicsSelected"
+			title:		qsTr("Selected")
+			maxRows:	5
 		}
 	}
 
@@ -69,8 +70,9 @@ Section
 
 			AssignedVariablesList
 			{
-				name:	"keywordsSelected"
-				title:	qsTr("Selected")
+				name:		"keywordsSelected"
+				title:		qsTr("Selected")
+				maxRows:	10
 			}
 		}
 


### PR DESCRIPTION
fixes: https://github.com/jasp-stats/jasp-test-release/issues/1696 by reducing the:
- number of selected topics to 5
- number of selected keywords to 10
but a better solution that allows showing only a subset of resulting output (e.g., split it into different "pages") is needed in order to reduce lag while not obstructing access to part of the data base